### PR TITLE
INFRA-1122: Changed context manager default_connection from admin actions to connection

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.3.0uh
+current_version = 1.4.0uh
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?P<releaselevel>[a-z]+)?

--- a/django_celery_monitor/__init__.py
+++ b/django_celery_monitor/__init__.py
@@ -10,7 +10,7 @@ import re
 
 from collections import namedtuple
 
-__version__ = '1.3.0uh'
+__version__ = '1.4.0uh'
 __author__ = 'Jannis Leidel'
 __contact__ = 'jannis@leidel.info'
 __homepage__ = 'https://github.com/jezdez/django-celery-monitor'

--- a/django_celery_monitor/admin.py
+++ b/django_celery_monitor/admin.py
@@ -174,26 +174,26 @@ class TaskMonitor(ModelMonitor):
 
     @action(_('Revoke selected tasks'))
     def revoke_tasks(self, request, queryset):
-        with current_app.default_connection() as connection:
+        with current_app.connection() as connection:
             for state in queryset:
                 revoke(state.task_id, connection=connection)
 
     @action(_('Terminate selected tasks'))
     def terminate_tasks(self, request, queryset):
-        with current_app.default_connection() as connection:
+        with current_app.connection() as connection:
             for state in queryset:
                 revoke(state.task_id, connection=connection, terminate=True)
 
     @action(_('Kill selected tasks'))
     def kill_tasks(self, request, queryset):
-        with current_app.default_connection() as connection:
+        with current_app.connection() as connection:
             for state in queryset:
                 revoke(state.task_id, connection=connection,
                        terminate=True, signal='KILL')
 
     @action(_('Retry selected tasks'))
     def retry_tasks(self, request, queryset):
-        with current_app.default_connection() as connection:
+        with current_app.connection() as connection:
             for state in queryset:
                 task = symbol_by_name(state.name)
                 kwargs = {
@@ -211,7 +211,7 @@ class TaskMonitor(ModelMonitor):
         app_label = opts.app_label
         if request.POST.get('post'):
             rate = request.POST['rate_limit']
-            with current_app.default_connection() as connection:
+            with current_app.connection() as connection:
                 for task_name in tasks:
                     rate_limit(task_name, rate, connection=connection)
             return None


### PR DESCRIPTION
The reason for this change is that default_connection tries to connect to the broker ignoring previously set variables for broker resulting in timeouts because of the not valid connection variables.