### PR TITLE
Change ugettext_lazy to gettext_lazy

### DIFF
--- a/django_celery_monitor/admin.py
+++ b/django_celery_monitor/admin.py
@@ -8,7 +8,7 @@ from django.contrib.admin.views import main as main_views
 from django.shortcuts import render
 from django.utils.encoding import force_text
 from django.utils.html import escape, format_html
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from celery import current_app
 from celery import states
@@ -94,8 +94,8 @@ def name(task):
     """Return the task name and abbreviates it to maximum of 16 characters."""
     short_name = abbrtask(task.name, 16)
     return format_html(
-        '<div title="{}"><b>{}</b></div>', 
-        escape(task.name), 
+        '<div title="{}"><b>{}</b></div>',
+        escape(task.name),
         escape(short_name)
     )
 

--- a/django_celery_monitor/apps.py
+++ b/django_celery_monitor/apps.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import, unicode_literals
 
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 __all__ = ['CeleryMonitorConfig']
 

--- a/django_celery_monitor/models.py
+++ b/django_celery_monitor/models.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, unicode_literals
 from time import time, mktime, gmtime
 
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.conf import settings
 
 from celery import states


### PR DESCRIPTION
We're getting the following in the logs. I'm looking into ways to reduce this clutter.

```
../../application/venv/lib/python3.8/site-packages/uh_core/phone/defaults.py:15
  /application/venv/lib/python3.8/site-packages/uh_core/phone/defaults.py:15: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
    MSG_INVALID_PHONE_NUMBER = _("Invalid Phone Number")

../../application/venv/lib/python3.8/site-packages/uh_core/admin_access/forms.py:97
  /application/venv/lib/python3.8/site-packages/uh_core/admin_access/forms.py:97: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
    username = forms.CharField(label=_("Username"), max_length=1512)

../../application/venv/lib/python3.8/site-packages/uh_core/admin_access/forms.py:111
  /application/venv/lib/python3.8/site-packages/uh_core/admin_access/forms.py:111: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
    username = forms.CharField(label=_("Username"), max_length=1512)

../../application/venv/lib/python3.8/site-packages/uh_core/admin_access/forms.py:112
  /application/venv/lib/python3.8/site-packages/uh_core/admin_access/forms.py:112: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
    email = forms.CharField(label=_("Email"), max_length=1512)

../../application/venv/lib/python3.8/site-packages/django_celery_monitor/admin.py:43
  /application/venv/lib/python3.8/site-packages/django_celery_monitor/admin.py:43: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
    @display_field(_('state'), 'state')

../../application/venv/lib/python3.8/site-packages/django_celery_monitor/admin.py:54
  /application/venv/lib/python3.8/site-packages/django_celery_monitor/admin.py:54: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
    @display_field(_('state'), 'last_heartbeat')

../../application/venv/lib/python3.8/site-packages/django_celery_monitor/admin.py:65
  /application/venv/lib/python3.8/site-packages/django_celery_monitor/admin.py:65: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
    @display_field(_('ETA'), 'eta')

../../application/venv/lib/python3.8/site-packages/django_celery_monitor/admin.py:73
  /application/venv/lib/python3.8/site-packages/django_celery_monitor/admin.py:73: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
    @display_field(_('when'), 'tstamp')

../../application/venv/lib/python3.8/site-packages/django_celery_monitor/admin.py:86
  /application/venv/lib/python3.8/site-packages/django_celery_monitor/admin.py:86: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
    @display_field(_('name'), 'name')

../../application/venv/lib/python3.8/site-packages/django_celery_monitor/admin.py:130
  /application/venv/lib/python3.8/site-packages/django_celery_monitor/admin.py:130: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
    detail_title = _('Task detail')

../../application/venv/lib/python3.8/site-packages/django_celery_monitor/admin.py:131
  /application/venv/lib/python3.8/site-packages/django_celery_monitor/admin.py:131: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
    list_page_title = _('Tasks')

../../application/venv/lib/python3.8/site-packages/django_celery_monitor/admin.py:148
  /application/venv/lib/python3.8/site-packages/django_celery_monitor/admin.py:148: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
    fixedwidth('task_id', name=_('UUID'), pt=8),

../../application/venv/lib/python3.8/site-packages/django_celery_monitor/admin.py:175
  /application/venv/lib/python3.8/site-packages/django_celery_monitor/admin.py:175: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
    @action(_('Revoke selected tasks'))

../../application/venv/lib/python3.8/site-packages/django_celery_monitor/admin.py:181
  /application/venv/lib/python3.8/site-packages/django_celery_monitor/admin.py:181: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
    @action(_('Terminate selected tasks'))

../../application/venv/lib/python3.8/site-packages/django_celery_monitor/admin.py:187
  /application/venv/lib/python3.8/site-packages/django_celery_monitor/admin.py:187: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
    @action(_('Kill selected tasks'))

../../application/venv/lib/python3.8/site-packages/django_celery_monitor/admin.py:194
  /application/venv/lib/python3.8/site-packages/django_celery_monitor/admin.py:194: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
    @action(_('Retry selected tasks'))

../../application/venv/lib/python3.8/site-packages/django_celery_monitor/admin.py:207
  /application/venv/lib/python3.8/site-packages/django_celery_monitor/admin.py:207: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
    @action(_('Rate limit selected tasks'))

../../application/venv/lib/python3.8/site-packages/django_celery_monitor/admin.py:245
  /application/venv/lib/python3.8/site-packages/django_celery_monitor/admin.py:245: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
    detail_title = _('Node detail')

../../application/venv/lib/python3.8/site-packages/django_celery_monitor/admin.py:246
  /application/venv/lib/python3.8/site-packages/django_celery_monitor/admin.py:246: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
    list_page_title = _('Worker Nodes')

../../application/venv/lib/python3.8/site-packages/django_celery_monitor/admin.py:253
  /application/venv/lib/python3.8/site-packages/django_celery_monitor/admin.py:253: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
    @action(_('Shutdown selected worker nodes'))

../../application/venv/lib/python3.8/site-packages/django_celery_monitor/admin.py:257
  /application/venv/lib/python3.8/site-packages/django_celery_monitor/admin.py:257: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
    @action(_('Enable event mode for selected nodes.'))

../../application/venv/lib/python3.8/site-packages/django_celery_monitor/admin.py:262
  /application/venv/lib/python3.8/site-packages/django_celery_monitor/admin.py:262: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
    @action(_('Disable event mode for selected nodes.'))
```